### PR TITLE
Fix notifications date bug

### DIFF
--- a/backend/notifier.py
+++ b/backend/notifier.py
@@ -98,7 +98,7 @@ def checkout_deputy(success_notifier, failure_notifier):
 
     json_data = get_json_data()
     deputies = json_data['records']
-    deputy = list(filter(lambda x: x['index'] == deputy_id, deputies))
+    deputy = list(filter(lambda x: x['date'] == get_today_timestamp().strftime('%Y-%m-%d'), deputies))
     if not deputy:
         failure_notifier.notify_error(
             f'El diputado de hoy no se encuentra en el archivo JSON.'


### PR DESCRIPTION
Al momento de obtener el diputado del día en las notificaciones, se deja de obtener por id y en su lugar se obtiene por timestamp del día actual.